### PR TITLE
Expose Collage and Msg

### DIFF
--- a/GraphicSVG.elm
+++ b/GraphicSVG.elm
@@ -7,7 +7,9 @@ module GraphicSVG
         , LineType
         , Face
         , Font
+        , Collage
         , collage
+        , Msg
         , map
         , GraphicsProgram
         , graphicsApp


### PR DESCRIPTION
Using cmdApp, I couldn't write a type declaration for my view function unless these constructors were exposed. 

```
main : CmdProgram Model Msg
main =
    cmdApp Tick { init = init, update = update, view = view, subscriptions = subscriptions }

...

-- Before this PR I get "Cannot find type `GraphicSVG.Collage`"
view : Model -> GraphicSVG.Collage (GraphicSVG.Msg msg) 
view = ...
```