### PR TITLE
Fix typo in gameApp spinner example

### DIFF
--- a/GraphicSVG.elm
+++ b/GraphicSVG.elm
@@ -634,7 +634,7 @@ causes the direction of the spin to reverse:
         collage 500 500
             [ line ( 0, 0 ) ( 250, 0 )
                 |> outlined (solid 1) green
-                |> rotate (degrees model)
+                |> rotate (degrees model.angle)
             ]
 
     main =


### PR DESCRIPTION
`|> rotate (degrees model.angle)` <- add missing `.angle` in the `view`