### PR TITLE
Repaint outlines together with bodies, outline groups, minor semantic…

### DIFF
--- a/src/GraphicSVG.elm
+++ b/src/GraphicSVG.elm
@@ -1774,7 +1774,7 @@ ghost stencil =
 
 {-| Repaint an already-`filled` `Shape`. This is helpful for repainting every `Shape` inside a `group` as well.
 
-Repaints the outline the same color as the body of the shape
+Repaints the outline the same color as the body of the shape including the outline, if used.
 
     group
         [ circle 10

--- a/src/Tests/InteractiveTest.elm
+++ b/src/Tests/InteractiveTest.elm
@@ -708,7 +708,7 @@ test21 =
                     |> move ( 225, 202.5 )
                     |> notifyTap (Notify ( 10, 10 ))
                 , openPolygon [ ( 100, 100 ), ( -100, 100 ), ( -100, -100 ), ( 100, -100 ) ]
-                    |> outlined (solid 1) black
+                    |> outlined (solid 1) black 
                     |> move ( -125, 0 )
                 , polygon [ ( 100, 100 ), ( -100, 100 ), ( -100, -100 ), ( 100, -100 ), ( 0, 0 ) ]
                     |> outlined (solid 1) black
@@ -1219,9 +1219,9 @@ test33 =
                     ]
                     |> move ( 225, 202.5 )
                     |> notifyTap (Notify ( 10, 10 ))
-                , circle 50
-                    |> filled blue
-                    |> clip (rect 100 100 |> filled purple |> move ( 50, 0 ))
+                , clip
+                    (circle 50 |> filled blue)
+                    (rect 100 100 |> filled purple |> move ( 50, 0 ))
                 ]
         )
         ( 0, 0 )
@@ -1289,9 +1289,9 @@ test35 =
                     ]
                     |> move ( 225, 202.5 )
                     |> notifyTap (Notify ( 10, 10 ))
-                , circle 50
-                    |> filled blue
-                    |> subtract (circle 50 |> filled purple |> move ( 50, 0 ))
+                , subtract
+                    (circle 50 |> filled blue)
+                    (circle 50 |> filled purple |> move ( 50, 0 ))
                 ]
         )
         ( 0, 0 )
@@ -1346,7 +1346,7 @@ test37 : Test
 test37 =
     Test
         "Testing ghost; click Pass or Fail as appropriate."
-        "Is there a white circle inside the red outline?:"
+        "Can you see the pink circle through the hole inside the red outline?:"
         (\model ->
             group
                 [ group
@@ -1369,7 +1369,119 @@ test37 =
                     ]
                     |> move ( 225, 202.5 )
                     |> notifyTap (Notify ( 10, 10 ))
+                , circle 40 |> filled pink
                 , circle 50 |> ghost |> addOutline (solid 1) red
+                ]
+        )
+        ( 0, 0 )
+
+
+test38 : Test
+test38 =
+    Test
+        "Testing adding outlines to groups; click Pass or Fail as appropriate."
+        "Can you see a purple outline around the group of joined and separate shapes?:"
+        (\model ->
+            group
+                [ group
+                    [ rect 40 15 |> filled grey |> addOutline (solid 0.5) black
+                    , text "Pass!!!"
+                        |> size 10
+                        |> centered
+                        |> outlined (solid 1) darkGreen
+                        |> move ( 0, -3 )
+                    ]
+                    |> move ( 175, 202.5 )
+                    |> notifyTap (Notify ( 0, 0 ))
+                , group
+                    [ rect 40 15 |> filled grey |> addOutline (solid 0.5) black
+                    , text "Failed!!!"
+                        |> size 10
+                        |> centered
+                        |> outlined (solid 1) red
+                        |> move ( 0, -3 )
+                    ]
+                    |> move ( 225, 202.5 )
+                    |> notifyTap (Notify ( 10, 10 ))
+                , group
+                    [ roundedRect 100 100 30 |> filled green
+                    , wedge 50 0.5 |> filled red |> rotate (turns 0.25) |> move ( 0, 50 )
+                    , isosceles 50 100 |> filled blue |> rotate (turns 0.5) |> move ( 0, -50 )
+                    , circle 50 |> filled orange |> move ( -150, 0 )
+                    ]
+                        |> addOutline (solid 5) darkPurple
+                ]
+        )
+        ( 0, 0 )
+
+
+test39 : Test
+test39 =
+    Test
+        "Testing adding outlines to clips; click Pass or Fail as appropriate."
+        "Can you see a purple outline around the orage circle clipped to the right side (interior lines)?:"
+        (\model ->
+            group
+                [ group
+                    [ rect 40 15 |> filled grey |> addOutline (solid 0.5) black
+                    , text "Pass!!!"
+                        |> size 10
+                        |> centered
+                        |> outlined (solid 1) darkGreen
+                        |> move ( 0, -3 )
+                    ]
+                    |> move ( 175, 202.5 )
+                    |> notifyTap (Notify ( 0, 0 ))
+                , group
+                    [ rect 40 15 |> filled grey |> addOutline (solid 0.5) black
+                    , text "Failed!!!"
+                        |> size 10
+                        |> centered
+                        |> outlined (solid 1) red
+                        |> move ( 0, -3 )
+                    ]
+                    |> move ( 225, 202.5 )
+                    |> notifyTap (Notify ( 10, 10 ))
+                , clip
+                    (circle 50 |> filled orange)
+                    (rect 100 100 |> filled red |> move ( 50, 0 ))
+                        |> addOutline (solid 5) purple
+                ]
+        )
+        ( 0, 0 )
+
+
+test40 : Test
+test40 =
+    Test
+        "Testing adding outlines to subtracts; click Pass or Fail as appropriate."
+        "Can you see a purple outline around the orange circle with a bite out on the right (interior lines)?:"
+        (\model ->
+            group
+                [ group
+                    [ rect 40 15 |> filled grey |> addOutline (solid 0.5) black
+                    , text "Pass!!!"
+                        |> size 10
+                        |> centered
+                        |> outlined (solid 1) darkGreen
+                        |> move ( 0, -3 )
+                    ]
+                    |> move ( 175, 202.5 )
+                    |> notifyTap (Notify ( 0, 0 ))
+                , group
+                    [ rect 40 15 |> filled grey |> addOutline (solid 0.5) black
+                    , text "Failed!!!"
+                        |> size 10
+                        |> centered
+                        |> outlined (solid 1) red
+                        |> move ( 0, -3 )
+                    ]
+                    |> move ( 225, 202.5 )
+                    |> notifyTap (Notify ( 10, 10 ))
+                , subtract
+                    (circle 50 |> filled orange)
+                    (circle 50 |> filled red |> move ( 50, 0 ))
+                        |> addOutline (solid 5) darkPurple
                 ]
         )
         ( 0, 0 )
@@ -1400,7 +1512,10 @@ testfinished =
 
 tests : Tests
 tests =
-    [ test0
+    [ test38
+    , test39
+    , test40
+    , test0
     , test1
     , test2
 
@@ -1439,6 +1554,7 @@ tests =
     , test35
     , test36
     , test37
+    , test38
 
     --    , testn etc.
     ]

--- a/src/Tests/InteractiveTest.elm
+++ b/src/Tests/InteractiveTest.elm
@@ -1512,10 +1512,7 @@ testfinished =
 
 tests : Tests
 tests =
-    [ test38
-    , test39
-    , test40
-    , test0
+    [ test0
     , test1
     , test2
 
@@ -1555,6 +1552,8 @@ tests =
     , test36
     , test37
     , test38
+    , test39
+    , test40
 
     --    , testn etc.
     ]

--- a/src/Tests/InteractiveTest.elm
+++ b/src/Tests/InteractiveTest.elm
@@ -7,6 +7,8 @@ import GraphicSVG.App exposing (GameApp, GetKeyState, KeyState(..), Keys(..), ga
 import Json.Decode as D
 import Time
 import Bitwise
+import Html exposing (button)
+import Html.Attributes exposing (style)
 
 
 
@@ -1150,6 +1152,40 @@ test31 =
 test32 : Test
 test32 =
     Test
+        "Testing inserting Html in the page; click on the Html button or Fail as appropriate."
+        "Testing response of Html button:"
+        (\model ->
+            group
+                [ html 40 15
+                    (button
+                        [ style "border" "1px solid Black"
+                        , style "width" "45px"
+                        , style "height" "15px"
+                        , style "font-size" "x-small"
+                        , style "color" "DarkGreen"
+                        ]
+                        [ Html.text "Pass!!!" ])
+                    |> move ( 155, 212.5 )
+                    |> notifyTap (Notify ( 0, 0 ))
+                , group
+                    [ rect 40 15 |> filled grey |> addOutline (solid 0.5) black
+                    , text "Failed!!!"
+                        |> size 10
+                        |> centered
+                        |> outlined (solid 1) red
+                        |> move ( 0, -3 )
+                    ]
+                    |> move ( 225, 202.5 )
+                    |> notifyTap (Notify ( 10, 10 ))
+                ]
+        )
+        ( 0, 0 )
+
+
+
+test33 : Test
+test33 =
+    Test
         "Testing repaint; click Pass or Fail as appropriate."
         "Does the circle colour change blue to purple and back every second?:"
         (\model ->
@@ -1192,8 +1228,8 @@ test32 =
         ( 0, 0 )
 
 
-test33 : Test
-test33 =
+test34 : Test
+test34 =
     Test
         "Testing clip; click Pass or Fail as appropriate."
         "Is the blue circle clipped to only its right half?:"
@@ -1227,8 +1263,8 @@ test33 =
         ( 0, 0 )
 
 
-test34 : Test
-test34 =
+test35 : Test
+test35 =
     Test
         "Testing union; click Pass or Fail as appropriate."
         "Is the shape a blue circle jointed on the right side by a purple (underlying) circle?:"
@@ -1262,8 +1298,8 @@ test34 =
         ( 0, 0 )
 
 
-test35 : Test
-test35 =
+test36 : Test
+test36 =
     Test
         "Testing subtraction; click Pass or Fail as appropriate."
         "Is the shape a blue circle with a circle \"bite\" taken out of it on the right side?:"
@@ -1297,8 +1333,8 @@ test35 =
         ( 0, 0 )
 
 
-test36 : Test
-test36 =
+test37 : Test
+test37 =
     Test
         "Testing outside; click Pass or Fail as appropriate."
         "Does the blue circle disappear every second, reappear the next?:"
@@ -1342,8 +1378,8 @@ test36 =
         ( 0, 0 )
 
 
-test37 : Test
-test37 =
+test38 : Test
+test38 =
     Test
         "Testing ghost; click Pass or Fail as appropriate."
         "Can you see the pink circle through the hole inside the red outline?:"
@@ -1376,8 +1412,8 @@ test37 =
         ( 0, 0 )
 
 
-test38 : Test
-test38 =
+test39 : Test
+test39 =
     Test
         "Testing adding outlines to groups; click Pass or Fail as appropriate."
         "Can you see a purple outline around the group of joined and separate shapes?:"
@@ -1415,8 +1451,8 @@ test38 =
         ( 0, 0 )
 
 
-test39 : Test
-test39 =
+test40 : Test
+test40 =
     Test
         "Testing adding outlines to clips; click Pass or Fail as appropriate."
         "Can you see a purple outline around the orage circle clipped to the right side (interior lines)?:"
@@ -1451,8 +1487,8 @@ test39 =
         ( 0, 0 )
 
 
-test40 : Test
-test40 =
+test41 : Test
+test41 =
     Test
         "Testing adding outlines to subtracts; click Pass or Fail as appropriate."
         "Can you see a purple outline around the orange circle with a bite out on the right (interior lines)?:"
@@ -1554,6 +1590,7 @@ tests =
     , test38
     , test39
     , test40
+    , test41
 
     --    , testn etc.
     ]

--- a/src/Tests/PositionTest.elm
+++ b/src/Tests/PositionTest.elm
@@ -1,8 +1,8 @@
 import GraphicSVG exposing (..)
 import GraphicSVG.App exposing (notificationsApp, NotificationsApp, GetKeyState)
 
-type alias Model = 
-    { pos : (Float, Float) }
+type alias Model =
+    (Float, Float)
 
 type Msg = 
       GoTo (Float,Float)
@@ -16,31 +16,17 @@ main = notificationsApp
 
 init : Model
 init = 
-    {
-        pos = (0,0)
-    }
+    ( 0, 0 )
 
 update : Msg -> Model -> Model
 update msg model =
     case msg of 
-        GoTo pos -> { model | pos = pos }
+        GoTo pos -> pos
 
 view : Model -> Collage Msg
 view model = collage 192 128 
     [ rect 192 128 |> filled green
-                    |> notifyMouseMoveAt GoTo
-    , circle 1 |> filled red |> move model.pos
-                |> notifyMouseMoveAt GoTo
+        |> notifyMouseMoveAt GoTo
+    , circle 1 |> filled red |> move model
+        |> notifyMouseMoveAt GoTo
     ]
-
-biggerButton = 
-    group 
-        [ circle 5 |> filled darkGrey
-        , rect 8 1 |> filled white 
-        , rect 1 8 |> filled white 
-        ]
-smallerButton = 
-    group 
-        [ circle 5 |> filled darkGrey
-        , rect 8 1 |> filled white
-        ]


### PR DESCRIPTION
… corrections...

Make the following corrections and additions:

1. Changed the abbreviations for `Stencil`'s inside functions from "sh" to "st" to better indicate the type.
1. Changed `ghost` to be `blank` colour body.
1. Changed `repaint` to change the colour of the outline as well as the colour of the body of a `Shape`.
1. Added a `NoLine` constructor to `LineType` and a `noline()` function to create this sub-type so `addOutline` can change an outlined shape to a not outlined shape as well as other uses.
1. Added the capability to `addOutline` to `Group`, `Clip` (result of a `clip` operation), and `AlphaMask` (result of a `subtract` operation) with half line stroke width, the limitations are noted in the documentation for `addOutline`.
1. Changed "InteractiveTest` to test all of the above, which passed for Chrome, Microsoft Edge, Microsoft Internet Explorer, and Firefox, Apple Safari yet to be tested.
1. Added "InteractiveTest" for foreign object HTML included with the SVG.
1. Simplified the "PositionTest" program.