### PR TITLE
tweaked clip and subtract for order of args, made body none a special…

### DIFF
--- a/src/GraphicSVG.elm
+++ b/src/GraphicSVG.elm
@@ -2476,10 +2476,10 @@ addOutline style outlineClr shape =
                         addOutline style outlineClr sh
 
                     ptrnoutln =
-                        clip inside ptrnlnd
+                        Clip inside ptrnlnd
 
                     shpoutln =
-                        clip inside newshp
+                        Clip inside newshp
                 in
                 AlphaMask ptrn <|
                     Group
@@ -2507,10 +2507,10 @@ addOutline style outlineClr shape =
                         addOutline style outlineClr sh
 
                     ptrnoutln =
-                        clip inside ptrnlnd
+                        Clip inside ptrnlnd
 
                     shpoutln =
-                        clip inside newshp
+                        Clip inside newshp
                 in
                 Clip ptrn <|
                     Group
@@ -2600,9 +2600,6 @@ addOutline style outlineClr shape =
 makeTransparent : Float -> Shape userMsg -> Shape userMsg
 makeTransparent alpha shape =
     case shape of
-        Inked Nothing Nothing st ->
-            shape
-
         Inked Nothing (Just ( lineType, RGBA sr sg sb sa )) st ->
             Inked Nothing (Just ( lineType, RGBA sr sg sb (sa * alpha) )) st
 
@@ -2702,6 +2699,9 @@ makeTransparent alpha shape =
 
         GraphPaper s th (RGBA r g b a) ->
             GraphPaper s th (RGBA r g b (a * alpha))
+        
+        Inked Nothing Nothing st ->
+            shape
 
 
 

--- a/src/GraphicSVG.elm
+++ b/src/GraphicSVG.elm
@@ -168,7 +168,7 @@ type Stencil
 {-| A filled, outlined, or filled and outlined object that can be drawn to the screen using `collage`.
 -}
 type Shape userMsg
-    = Inked Color (Maybe ( LineType, Color )) Stencil
+    = Inked (Maybe Color) (Maybe ( LineType, Color )) Stencil
     | ForeignObject Float Float (Html.Html userMsg)
     | Move ( Float, Float ) (Shape userMsg)
     | Rotate Float (Shape userMsg)
@@ -925,13 +925,16 @@ wedge r frac =
 
         ni =
             round n
+
+        dlta =
+            frac / Basics.toFloat ni
     in
     Polygon <|
         if frac > 0 then
             [ ( 0, 0 ), wedgeHelper r -frac ]
                 ++ List.map
                     (wedgeHelper r
-                        << (*) (frac / n)
+                        << (*) dlta
                         << Basics.toFloat
                     )
                     (List.range -ni ni)
@@ -1767,16 +1770,24 @@ createSVG id w h trans shape =
                         "matrix("
                             ++ (String.concat <|
                                     List.intersperse "," <|
-                                        List.map String.fromFloat [ a, -b, c, -d, tx, -ty ]
+                                        List.map
+                                            String.fromFloat
+                                            [ a, -b, c, -d, tx, -ty ]
                                )
                             ++ ")"
                     ]
 
-                nonexistBody = let (RGBA _ _ _ opcty) = fillClr in opcty <= 0
+                nonexistBody =
+                    case fillClr of
+                        Nothing -> True
+                        _ -> False
                 
                 clrAttrs =
-                    if nonexistBody then [ fill "none"]
-                    else [ fill (mkRGB fillClr), fillOpacity (mkAlpha fillClr) ]
+                    case fillClr of
+                        Nothing -> [ fill "none"]
+                        Just bodyClr -> [ fill (mkRGB bodyClr)
+                                        , fillOpacity (mkAlpha bodyClr)
+                                        ]
 
                 strokeAttrs =
                     case lt of
@@ -2175,7 +2186,11 @@ html w h htm =
 --Filling / outlining functions
 
 
-{-| Fill a `Stencil` with a `Color`, creating a `Shape`.
+{-| Fill a `Stencil` with a `Color`, creating a `Shape`;
+Note that any `Stencil` converted to a `Shape` this way can be made
+transparent (for instance by using the `blank` `Color`) but will not be
+"click-through", meaning that the body will catch any attached notifications
+and not let them through to any visible `Shape`(s) revealed beneath them.
 
     circle 10
         |> filled red
@@ -2183,19 +2198,24 @@ html w h htm =
 -}
 filled : Color -> Stencil -> Shape userMsg
 filled color stencil =
-    Inked color Nothing stencil
+    Inked (Just color) Nothing stencil
 
 
 {-| Make a `Shape` into a ghost. Mostly to be used inside of the clip operations.
+Note that although the `blank` `Color` is transparent, it will still catch
+notifications enabled on the `Shape` or block them if not enabled on the `Shape`.
 -}
 ghost : Stencil -> Shape userMsg
 ghost stencil =
-    Inked blank Nothing stencil
+    Inked (Just blank) Nothing stencil
 
 
 {-| Repaint an already-`filled` `Shape`. This is helpful for repainting every `Shape` inside a `group` as well.
 
-Repaints the outline the same color as the body of the shape including the outline, if used.
+Repaints the outline the same color as the body of the shape including the outline, if used;
+Note that this can repaint with a transparent `Color` (for instance, the `blank` `Color`) but
+will never have the ability to be "click-through" so that it will always block (or catch)
+notifications to covered `Shape`(s) revealed beneath.
 
     group
         [ circle 10
@@ -2210,10 +2230,10 @@ repaint : Color -> Shape userMsg -> Shape userMsg
 repaint color shape =
     case shape of
         Inked _ Nothing st ->
-            Inked color Nothing st
+            Inked (Just color) Nothing st
 
         Inked _ (Just ( lt, _ )) st ->
-            Inked color (Just ( lt, color )) st
+            Inked (Just color) (Just ( lt, color )) st
 
         Move s sh ->
             Move s (repaint color sh)
@@ -2307,7 +2327,11 @@ repaint color shape =
             GraphPaper s th color
 
 
-{-| Outline a Stencil with a `LineType` and `Color`, creating a `Shape`.
+{-| Outline a Stencil with a `LineType` and `Color`, creating a `Shape`;
+Note that this is the only way to convert a `Stencil` into a `Shape` that is
+"click-through" as if the body is not just transparent but doesn't exist at all.
+It works for all `Stencil`'s except for `Text` which can never be made "click-through"
+due to a permanent transparent background area that cannot be disabled.
 
     circle 10
         |> outlined (solid 5) red
@@ -2324,7 +2348,7 @@ outlined style outlineClr stencil =
                 _ ->
                     Just ( style, outlineClr )
     in
-    Inked (rgba 0 0 0 0) lineStyle stencil
+    Inked Nothing lineStyle stencil
 
 
 {-| Add an outline to an already-filled `Shape`.
@@ -2343,6 +2367,11 @@ the pattern is a "Group" as it won't appear at all in a "clip".
 In these cases the workaround is just as before this was made available, to build up
 the outlines desired using combinations of other shapes such as curves, clipped or
 subtracted shapes, convential pre-applied outlines, etc.
+
+Note that when applied to `Group`(s), `Clip`(s), and `AlphaMask`(s) (from subtracts),
+the body colour may still be transparent so that `Shape`(s) can be revealed beneath,
+but the bodies are not "click-through" so that notifications can be passed through to them,
+and the transparent bodies can still capture notifications enabled on the resulting `Shape`(s).
 
     circle 10
         |> filled red
@@ -2411,13 +2440,13 @@ addOutline style outlineClr shape =
                             outlnshp =
                                 GroupOutline <|
                                     subtract
+                                        (Group innerlist)
                                         (Group
                                             (List.map
                                                 (addOutline style outlineClr)
                                                 innerlist
                                             )
                                         )
-                                        (Group innerlist)
                         in
                         Group <| innerlist ++ [ outlnshp ]
 
@@ -2447,10 +2476,10 @@ addOutline style outlineClr shape =
                         addOutline style outlineClr sh
 
                     ptrnoutln =
-                        clip ptrnlnd inside
+                        clip inside ptrnlnd
 
                     shpoutln =
-                        clip newshp inside
+                        clip inside newshp
                 in
                 AlphaMask ptrn <|
                     Group
@@ -2478,10 +2507,10 @@ addOutline style outlineClr shape =
                         addOutline style outlineClr sh
 
                     ptrnoutln =
-                        clip ptrnlnd inside
+                        clip inside ptrnlnd
 
                     shpoutln =
-                        clip newshp inside
+                        clip inside newshp
                 in
                 Clip ptrn <|
                     Group
@@ -2571,11 +2600,18 @@ addOutline style outlineClr shape =
 makeTransparent : Float -> Shape userMsg -> Shape userMsg
 makeTransparent alpha shape =
     case shape of
-        Inked (RGBA r g b a) (Just ( lineType, RGBA sr sg sb sa )) st ->
-            Inked (RGBA r g b (a * alpha)) (Just ( lineType, RGBA sr sg sb (sa * alpha) )) st
+        Inked Nothing Nothing st ->
+            shape
 
-        Inked (RGBA r g b a) Nothing st ->
-            Inked (RGBA r g b (a * alpha)) Nothing st
+        Inked Nothing (Just ( lineType, RGBA sr sg sb sa )) st ->
+            Inked Nothing (Just ( lineType, RGBA sr sg sb (sa * alpha) )) st
+
+        Inked (Just (RGBA r g b a)) (Just ( lineType, RGBA sr sg sb sa )) st ->
+            Inked (Just (RGBA r g b (a * alpha)))
+                  (Just ( lineType, RGBA sr sg sb (sa * alpha) )) st
+
+        Inked (Just (RGBA r g b a)) Nothing st ->
+            Inked (Just (RGBA r g b (a * alpha))) Nothing st
 
         ForeignObject w h htm ->
             ForeignObject w h htm
@@ -3143,12 +3179,12 @@ union shape1 shape2 =
 
 {-| Shape subtraction
 
-Subtract the `Shape` on the right from the `Shape` on the left.
+Subtract the `Shape` on the left from the `Shape` on the right.
 
 -}
 subtract : Shape userMsg -> Shape userMsg -> Shape userMsg
 subtract shape1 shape2 =
-    AlphaMask shape2 shape1
+    AlphaMask shape1 shape2
 
 
 {-| The whole region outside the given `Shape`.

--- a/src/Tests/InteractiveTest.elm
+++ b/src/Tests/InteractiveTest.elm
@@ -1257,8 +1257,8 @@ test34 =
                     |> move ( 225, 202.5 )
                     |> notifyTap (Notify ( 10, 10 ))
                 , clip
-                    (circle 50 |> filled blue)
                     (rect 100 100 |> filled purple |> move ( 50, 0 ))
+                    (circle 50 |> filled blue)
                 ]
         )
         ( 0, 0 )
@@ -1303,7 +1303,7 @@ test36 : Test
 test36 =
     Test
         "Testing subtraction; click Pass or Fail as appropriate."
-        "Is the shape a blue circle with a circle \"bite\" taken out of it on the right side?:"
+        "Is the shape a blue circle with a circle \"bite\" taken out of it on the left side?:"
         (\_ ->
             group
                 [ group
@@ -1327,8 +1327,8 @@ test36 =
                     |> move ( 225, 202.5 )
                     |> notifyTap (Notify ( 10, 10 ))
                 , subtract
+                    (circle 50 |> filled purple |> move ( -50, 0 ))
                     (circle 50 |> filled blue)
-                    (circle 50 |> filled purple |> move ( 50, 0 ))
                 ]
         )
         ( 0, 0 )
@@ -1480,9 +1480,9 @@ test40 =
                     |> move ( 225, 202.5 )
                     |> notifyTap (Notify ( 10, 10 ))
                 , clip
-                    (circle 50 |> filled orange)
                     (rect 100 100 |> filled red |> move ( 50, 0 ))
-                    |> addOutline (solid 5) purple
+                    (circle 50 |> filled orange)
+                        |> addOutline (solid 5) purple
                 ]
         )
         ( 0, 0 )
@@ -1516,9 +1516,9 @@ test41 =
                     |> move ( 225, 202.5 )
                     |> notifyTap (Notify ( 10, 10 ))
                 , subtract
+                    (circle 50 |> filled red |> move ( -50, 0 ))
                     (circle 50 |> filled orange)
-                    (circle 50 |> filled red |> move ( 50, 0 ))
-                    |> addOutline (solid 5) darkPurple
+                        |> addOutline (solid 5) darkPurple
                 ]
         )
         ( 0, 0 )
@@ -1558,13 +1558,13 @@ test42 =
                     , circle 50 |> filled orange |> move ( -150, 0 )
                     , circle 25 |> filled blue |> move ( -150, 0 )
                     , subtract
-                        (circle 50 |> filled orange)
                         (rect 100 100 |> filled red |> move ( 50, 0 ))
-                        |> move ( -25, 0 )
+                        (circle 50 |> filled orange)
+                            |> move ( -25, 0 )
                     , clip
-                        (circle 50 |> filled orange)
                         (rect 100 100 |> filled red |> move ( 50, 0 ))
-                        |> move ( 25, 0 )
+                        (circle 50 |> filled orange)
+                            |> move ( 25, 0 )
                     ]
                     |> addOutline (solid 5) darkPurple
                 ]
@@ -1602,26 +1602,24 @@ test43 =
                 , addOutline (solid 5) purple <|
                     clip
                         (group
+                            [ rect 200 100 |> filled red |> move ( 0, 50 )
+                            , clip
+                                (rect 50 50 |> filled green |> move ( -25, -60 ))
+                                (circle 25 |> filled red |> move ( -25, -35 ))
+                            , subtract
+                                (rect 50 50 |> filled green |> move ( 25, -10 ))
+                                (circle 25 |> filled red |> move ( 25, -35 ))
+                            ])
+                        (group
                             [ rect 150 110 |> filled red
                             , circle 50 |> filled orange
                             , clip
-                                (circle 50 |> filled yellow |> move ( -25, 0 ))
                                 (rect 100 100 |> filled green |> move ( -75, 0 ))
+                                (circle 50 |> filled yellow |> move ( -25, 0 ))
                             , subtract
-                                (circle 50 |> filled yellow |> move ( 25, 0 ))
                                 (rect 100 100 |> filled green |> move ( -25, 0 ))
-                            ]
-                        )
-                        (group
-                            [ rect 200 100 |> filled red |> move ( 0, 50 )
-                            , clip
-                                (circle 25 |> filled red |> move ( -25, -35 ))
-                                (rect 50 50 |> filled green |> move ( -25, -60 ))
-                            , subtract
-                                (circle 25 |> filled red |> move ( 25, -35 ))
-                                (rect 50 50 |> filled green |> move ( 25, -10 ))
-                            ]
-                        )
+                                (circle 50 |> filled yellow |> move ( 25, 0 ))
+                            ])
                 ]
         )
         ( 0, 0 )
@@ -1657,27 +1655,25 @@ test44 =
                 , addOutline (solid 5) purple <|
                     subtract
                         (group
-                            [ rect 150 110 |> filled red
-                            , circle 50 |> filled orange
-                            , clip
-                                (circle 50 |> filled yellow |> move ( -25, 0 ))
-                                (rect 100 100 |> filled green |> move ( -75, 0 ))
-                            , subtract
-                                (circle 50 |> filled yellow |> move ( 25, 0 ))
-                                (rect 100 100 |> filled green |> move ( -25, 0 ))
-                            ]
-                        )
-                        (group
                             [ rect 200 100 |> filled red |> move ( 0, 50 )
                             , rect 100 10 |> filled red |> move ( 0, -15 )
                             , clip
-                                (circle 25 |> filled red |> move ( -25, -35 ))
                                 (rect 50 50 |> filled green |> move ( -25, -60 ))
+                                (circle 25 |> filled red |> move ( -25, -35 ))
                             , subtract
-                                (circle 25 |> filled red |> move ( 25, -35 ))
                                 (rect 50 50 |> filled green |> move ( 25, -10 ))
-                            ]
-                        )
+                                (circle 25 |> filled red |> move ( 25, -35 ))
+                            ])
+                        (group
+                            [ rect 150 110 |> filled red
+                            , circle 50 |> filled orange
+                            , clip
+                                (rect 100 100 |> filled green |> move ( -75, 0 ))
+                                (circle 50 |> filled yellow |> move ( -25, 0 ))
+                            , subtract
+                                (rect 100 100 |> filled green |> move ( -25, 0 ))
+                                (circle 50 |> filled yellow |> move ( 25, 0 ))
+                            ])
                 ]
         )
         ( 0, 0 )


### PR DESCRIPTION
… case, etc.

This change includes the follows:

1)  The order of arguments to `clip` and `subract` are reversed so the pattern comes first as has become an Elm standard to easily permit  partial application of these funcctions to many `Shape`'s.

2)  Corrections are made so that all `Shape`'s other than `Text` `Shape`'s have a non-existant "click-through" body when created using `outlined` and not changed with `repaint` or some cases for `addOutline` with all other means of converting `Stencil`'s to `Shape`'s having the possibilty of creating transparent `Shape` bodies that are not "click-through" as they will still catch and/or black notifications with documentation added to all of the pertinent functions that deal with color describing these limitations.

3)  While confirming testing of the above, it was noticed that the `wedge` shape arc was not exact due to rounding errors in converting to a range of integers, this was corrected to reapproximate the delta between the approximating polygon points for a more exact length of arc.

4)  The "InteractiveTest" program was modified to test all of the above.