### PR TITLE
Secret split

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "MacCASOutreach/graphicsvg",
     "summary": "Beautiful scalable vector graphics (SVG) in Elm.",
     "license": "BSD-3-Clause",
-    "version": "7.2.0",
+    "version": "8.0.0",
     "exposed-modules": [
         "GraphicSVG",
         "GraphicSVG.App",

--- a/src/GraphicSVG.elm
+++ b/src/GraphicSVG.elm
@@ -1,5 +1,5 @@
 module GraphicSVG exposing
-    ( Stencil, Shape, Collage(..), GraphicSVG
+    ( Collage(..), GraphicSVG
     , collage, mapCollage
     , App, app
     , EllieApp, ellieApp
@@ -7,8 +7,8 @@ module GraphicSVG exposing
     , filled, outlined, repaint, addOutline, rgb, rgba, hsl, hsla
     , group
     , html
-    , curve, Pull(..), curveHelper
-    , LineType, noline, solid, dotted, dashed, longdash, dotdash, custom
+    , curve, curveHelper
+    , noline, solid, dotted, dashed, longdash, dotdash, custom
     , text, size, bold, italic, underline, strikethrough, centered, alignLeft, alignRight, selectable, sansserif, serif, fixedwidth, customFont
     , move, rotate, scale, scaleX, scaleY, mirrorX, mirrorY, skewX, skewY
     , clip, union, subtract, outside, ghost
@@ -16,8 +16,8 @@ module GraphicSVG exposing
     , makeTransparent, addHyperlink, puppetShow
     , graphPaper, graphPaperCustom, map
     , gradient, radialGradient, stop, transparentStop, rotateGradient
-    , Color, black, blank, blue, brown, charcoal, darkBlue, darkBrown, darkCharcoal, darkGray, darkGreen, darkGrey, darkOrange, darkPurple, darkRed, darkYellow, gray, green, grey, hotPink, lightBlue, lightBrown, lightCharcoal, lightGray, lightGreen, lightGrey, lightOrange, lightPurple, lightRed, lightYellow, orange, pink, purple, red, white, yellow
-    , Transform, ident, moveT, rotateT, scaleT, skewT, rotateAboutT, transform
+    , black, blank, blue, brown, charcoal, darkBlue, darkBrown, darkCharcoal, darkGray, darkGreen, darkGrey, darkOrange, darkPurple, darkRed, darkYellow, gray, green, grey, hotPink, lightBlue, lightBrown, lightCharcoal, lightGray, lightGreen, lightGrey, lightOrange, lightPurple, lightRed, lightYellow, orange, pink, purple, red, white, yellow
+    , ident, moveT, rotateT, scaleT, skewT, rotateAboutT, transform
     , Msg(..), createSVG
     )
 
@@ -161,62 +161,20 @@ import Time exposing (..)
 import Tuple
 import Url exposing (Url)
 import Color
+import GraphicSVG.Secret 
+    exposing(Shape(..)
+            , Stencil(..)
+            , Color(..)
+            , Face(..)
+            , Font(..)
+            , FontAlign(..)
+            , LineType(..)
+            , Transform
+            , Pull(..)
+            , Gradient(..)
+            , Stop(..)
+            )
 
-
-{-| A primitive template representing the shape you wish to draw. This must be turned into
-a `Shape` before being drawn to the screen with `collage` (see below).
--}
-type Stencil
-    = Circle Float
-    | Rect Float Float
-    | RoundRect Float Float Float
-    | Oval Float Float
-    | BezierPath ( Float, Float ) (List ( ( Float, Float ), ( Float, Float ) ))
-    | Polygon (List ( Float, Float ))
-    | Path (List ( Float, Float ))
-    | Text Face String
-
-
-{-| A filled, outlined, or filled and outlined object that can be drawn to the screen using `collage`.
--}
-type Shape userMsg
-    = Inked (Maybe Color) (Maybe ( LineType, Color )) Stencil
-    | ForeignObject Float Float (Html.Html userMsg)
-    | Move ( Float, Float ) (Shape userMsg)
-    | Rotate Float (Shape userMsg)
-    | Scale Float Float (Shape userMsg)
-    | Skew Float Float (Shape userMsg)
-    | Transformed Transform (Shape userMsg)
-    | Group (List (Shape userMsg))
-    | GroupOutline (Shape userMsg)
-    | AlphaMask (Shape userMsg) (Shape userMsg)
-    | Clip (Shape userMsg) (Shape userMsg)
-    | Everything
-    | Notathing
-    | Link String (Shape userMsg)
-    | Tap userMsg (Shape userMsg)
-    | TapAt (( Float, Float ) -> userMsg) (Shape userMsg)
-    | EnterShape userMsg (Shape userMsg)
-    | EnterAt (( Float, Float ) -> userMsg) (Shape userMsg)
-    | Exit userMsg (Shape userMsg)
-    | ExitAt (( Float, Float ) -> userMsg) (Shape userMsg)
-    | MouseDown userMsg (Shape userMsg)
-    | MouseDownAt (( Float, Float ) -> userMsg) (Shape userMsg)
-    | MouseUp userMsg (Shape userMsg)
-    | MouseUpAt (( Float, Float ) -> userMsg) (Shape userMsg)
-    | MoveOverAt (( Float, Float ) -> userMsg) (Shape userMsg)
-    | TouchStart userMsg (Shape userMsg)
-    | TouchEnd userMsg (Shape userMsg)
-    | TouchStartAt (( Float, Float ) -> userMsg) (Shape userMsg)
-    | TouchEndAt (( Float, Float ) -> userMsg) (Shape userMsg)
-    | TouchMoveAt (( Float, Float ) -> userMsg) (Shape userMsg)
-    | GraphPaper Float Float Color
-
-
-type FontAlign
-    = AlignLeft
-    | AlignCentred
-    | AlignRight
 
 
 {-| To compose multiple pages or components which each have a Msg/view/update, we need to map messages.
@@ -351,16 +309,6 @@ type alias GraphicSVG userMsg =
     Collage userMsg
 
 
-{-| The `Color` type is used for filling or outlining a `Stencil`.
--}
-type Color
-    = Solid Color.Color
-    | Gradient Gradient
-
-type Gradient =
-      RadialGradient (List Stop)
-    | LinearGradient Float {- rotation -} (List Stop)
-
 {-| Create a radial gradient from a list of colour stops.
 -}
 radialGradient : List Stop -> Color
@@ -380,9 +328,6 @@ rotateGradient r grad =
     case grad of
         Gradient (LinearGradient rot stops) -> Gradient (LinearGradient (rot + r) stops)
         radialGrad -> radialGrad
-
-type Stop =
-    Stop Float {- stop position -} Float {- transparency -} Color.Color {- colour -}
 
 {-| A colour stop in a gradient. This takes a colour and a position.
 -}
@@ -475,57 +420,6 @@ createGradientSVG id (wid, hei) grad =
                    )
                    []
             ]
-
-{-| The `LineType` type is used to define the appearance of an outline for a `Stencil`.
-`LineType` also defines the appearence of `line` and `curve`.
--}
-type LineType
-    = NoLine
-    | Unbroken Float
-    | Broken (List ( Float, Float )) Float
-
-
-{-| The `Face` type describes the appearance of a text `Stencil`.
-THIS IS NOT EXPOSED BY ANY TYPE AND IS NOW NOT EXPOSED BY THE LIBARY.
--}
-type Face
-    = Face
-        Float
-        -- size
-        Bool
-        -- bold
-        Bool
-        -- italic
-        Bool
-        -- underline
-        Bool
-        -- strikethrough
-        Bool
-        -- selectable
-        Font
-        -- font alignment
-        FontAlign
-
-
-{-| The `Font` type describes the font of a text `Stencil`.
-THIS IS NOT EXPOSED BY ANY TYPE AND IS NOW NOT EXPOSED BY THE LIBARY.
--}
-type Font
-    = Serif
-    | Sansserif
-    | FixedWidth
-    | Custom String
-
-
-{-| To make it easier to read the code defining a `curve`,
-and to make sure we always use the right number of curve points
-and pull points (which is one more curve point than pull points),
-we define a special `Pull` type, whose first point is the point
-we pull towards, and second point is the end point for this
-curve segments.
--}
-type Pull
-    = Pull ( Float, Float ) ( Float, Float )
 
 
 {-| _Advanced Function Warning!_ `app` takes one parameter of its own type of the form:
@@ -1375,38 +1269,6 @@ ident =
     ( ( 1, 0, 0 )
     , ( 0, 1, 0 )
     )
-
-
-{-| A matrix representing an SVG transformation matrix of the form:
-
-```
-( ( a , c , e ) , ( b , d , f ) )
-```
-
-or
-
-```
- a c e
- b d f
-```
-
-The a, c, b and d control transformations such as skew, rotate and scale;
-e and f control translation.
-
-These matrices are best built up by starting with the identity matrix and
-applying any number of `*T` functions (see below); for example,
-
-```
-myTransform =
-    ident
-        |> scaleT 2 2
-        |> rotateT (degrees 30)
-        |> moveT (0, 50)
-```
-
--}
-type alias Transform =
-    ( ( Float, Float, Float ), ( Float, Float, Float ) )
 
 
 {-| Apply a move (translation) transformation to a transformation matrix.

--- a/src/GraphicSVG.elm
+++ b/src/GraphicSVG.elm
@@ -1,5 +1,6 @@
 module GraphicSVG exposing
-    ( Collage(..), GraphicSVG
+    ( Shape, Stencil
+    , Collage(..), GraphicSVG
     , collage, mapCollage
     , App, app
     , EllieApp, ellieApp
@@ -71,12 +72,12 @@ not guaranteed and weird things can happen.
 
 # Curves
 
-@docs curve, Pull, curveHelper
+@docs curve, curveHelper
 
 
 # Line Styles
 
-@docs LineType, noline, solid, dotted, dashed, longdash, dotdash, custom
+@docs noline, solid, dotted, dashed, longdash, dotdash, custom
 
 
 # Text
@@ -111,7 +112,7 @@ not guaranteed and weird things can happen.
 
 # Let there be colours!
 
-@docs Color, black, blank, blue, brown, charcoal, darkBlue, darkBrown, darkCharcoal, darkGray, darkGreen, darkGrey, darkOrange, darkPurple, darkRed, darkYellow, gray, green, grey, hotPink, lightBlue, lightBrown, lightCharcoal, lightGray, lightGreen, lightGrey, lightOrange, lightPurple, lightRed, lightYellow, orange, pink, purple, red, white, yellow
+@docs black, blank, blue, brown, charcoal, darkBlue, darkBrown, darkCharcoal, darkGray, darkGreen, darkGrey, darkOrange, darkPurple, darkRed, darkYellow, gray, green, grey, hotPink, lightBlue, lightBrown, lightCharcoal, lightGray, lightGreen, lightGrey, lightOrange, lightPurple, lightRed, lightYellow, orange, pink, purple, red, white, yellow
 
 
 # Let there be gradients!
@@ -125,7 +126,7 @@ level to the transformations normally handled in the background by GraphicSVG.
 Most users should be happy to use the regular functions applied directly to shapes,
 which are provided in the section above this one.
 
-@docs Transform, ident, moveT, rotateT, scaleT, skewT, rotateAboutT, transform
+@docs ident, moveT, rotateT, scaleT, skewT, rotateAboutT, transform
 
 # More Advanced Things
 
@@ -175,6 +176,15 @@ import GraphicSVG.Secret
             , Stop(..)
             )
 
+
+{-| A filled, outlined, or filled and outlined object that can be drawn to the screen using `collage`.
+-}
+type alias Stencil = GraphicSVG.Secret.Stencil
+
+{-| A primitive template representing the shape you wish to draw. This must be turned into
+a `Shape` before being drawn to the screen with `collage` (see below).
+-}
+type alias Shape userMsg = GraphicSVG.Secret.Shape userMsg
 
 
 {-| To compose multiple pages or components which each have a Msg/view/update, we need to map messages.

--- a/src/GraphicSVG/Secret.elm
+++ b/src/GraphicSVG/Secret.elm
@@ -1,0 +1,158 @@
+module GraphicSVG.Secret exposing (..)
+
+import Html
+import Color
+
+
+{-| A primitive template representing the shape you wish to draw. This must be turned into
+a `Shape` before being drawn to the screen with `collage` (see below).
+-}
+type Stencil
+    = Circle Float
+    | Rect Float Float
+    | RoundRect Float Float Float
+    | Oval Float Float
+    | BezierPath ( Float, Float ) (List ( ( Float, Float ), ( Float, Float ) ))
+    | Polygon (List ( Float, Float ))
+    | Path (List ( Float, Float ))
+    | Text Face String
+
+
+{-| A filled, outlined, or filled and outlined object that can be drawn to the screen using `collage`.
+-}
+type Shape userMsg
+    = Inked (Maybe Color) (Maybe ( LineType, Color )) Stencil
+    | ForeignObject Float Float (Html.Html userMsg)
+    | Move ( Float, Float ) (Shape userMsg)
+    | Rotate Float (Shape userMsg)
+    | Scale Float Float (Shape userMsg)
+    | Skew Float Float (Shape userMsg)
+    | Transformed Transform (Shape userMsg)
+    | Group (List (Shape userMsg))
+    | GroupOutline (Shape userMsg)
+    | AlphaMask (Shape userMsg) (Shape userMsg)
+    | Clip (Shape userMsg) (Shape userMsg)
+    | Everything
+    | Notathing
+    | Link String (Shape userMsg)
+    | Tap userMsg (Shape userMsg)
+    | TapAt (( Float, Float ) -> userMsg) (Shape userMsg)
+    | EnterShape userMsg (Shape userMsg)
+    | EnterAt (( Float, Float ) -> userMsg) (Shape userMsg)
+    | Exit userMsg (Shape userMsg)
+    | ExitAt (( Float, Float ) -> userMsg) (Shape userMsg)
+    | MouseDown userMsg (Shape userMsg)
+    | MouseDownAt (( Float, Float ) -> userMsg) (Shape userMsg)
+    | MouseUp userMsg (Shape userMsg)
+    | MouseUpAt (( Float, Float ) -> userMsg) (Shape userMsg)
+    | MoveOverAt (( Float, Float ) -> userMsg) (Shape userMsg)
+    | TouchStart userMsg (Shape userMsg)
+    | TouchEnd userMsg (Shape userMsg)
+    | TouchStartAt (( Float, Float ) -> userMsg) (Shape userMsg)
+    | TouchEndAt (( Float, Float ) -> userMsg) (Shape userMsg)
+    | TouchMoveAt (( Float, Float ) -> userMsg) (Shape userMsg)
+    | GraphPaper Float Float Color
+
+
+type FontAlign
+    = AlignLeft
+    | AlignCentred
+    | AlignRight
+
+
+{-| The `Color` type is used for filling or outlining a `Stencil`.
+-}
+type Color
+    = Solid Color.Color
+    | Gradient Gradient
+
+type Gradient =
+      RadialGradient (List Stop)
+    | LinearGradient Float {- rotation -} (List Stop)
+
+type Stop =
+    Stop Float {- stop position -} Float {- transparency -} Color.Color {- colour -}
+
+
+{-| A matrix representing an SVG transformation matrix of the form:
+
+```
+( ( a , c , e ) , ( b , d , f ) )
+```
+
+or
+
+```
+ a c e
+ b d f
+```
+
+The a, c, b and d control transformations such as skew, rotate and scale;
+e and f control translation.
+
+These matrices are best built up by starting with the identity matrix and
+applying any number of `*T` functions (see below); for example,
+
+```
+myTransform =
+    ident
+        |> scaleT 2 2
+        |> rotateT (degrees 30)
+        |> moveT (0, 50)
+```
+
+-}
+type alias Transform =
+    ( ( Float, Float, Float ), ( Float, Float, Float ) )
+
+
+{-| The `LineType` type is used to define the appearance of an outline for a `Stencil`.
+`LineType` also defines the appearence of `line` and `curve`.
+-}
+type LineType
+    = NoLine
+    | Unbroken Float
+    | Broken (List ( Float, Float )) Float
+
+
+{-| The `Face` type describes the appearance of a text `Stencil`.
+THIS IS NOT EXPOSED BY ANY TYPE AND IS NOW NOT EXPOSED BY THE LIBARY.
+-}
+type Face
+    = Face
+        Float
+        -- size
+        Bool
+        -- bold
+        Bool
+        -- italic
+        Bool
+        -- underline
+        Bool
+        -- strikethrough
+        Bool
+        -- selectable
+        Font
+        -- font alignment
+        FontAlign
+
+
+{-| The `Font` type describes the font of a text `Stencil`.
+THIS IS NOT EXPOSED BY ANY TYPE AND IS NOW NOT EXPOSED BY THE LIBARY.
+-}
+type Font
+    = Serif
+    | Sansserif
+    | FixedWidth
+    | Custom String
+
+
+{-| To make it easier to read the code defining a `curve`,
+and to make sure we always use the right number of curve points
+and pull points (which is one more curve point than pull points),
+we define a special `Pull` type, whose first point is the point
+we pull towards, and second point is the end point for this
+curve segments.
+-}
+type Pull
+    = Pull ( Float, Float ) ( Float, Float )

--- a/src/GraphicSVG/Secret.elm
+++ b/src/GraphicSVG/Secret.elm
@@ -1,5 +1,30 @@
 module GraphicSVG.Secret exposing (..)
 
+{-| Advanced Secret module! This is for people who want to access the
+underlying types in the library so you can do advanced things. Most people
+don't need this much detail! I recommend you look at the source of this 
+module to determine how to use these.
+
+# Shapes and Stencils
+@docs Stencil, Shape
+
+# Colours and Gradients
+@docs Color, Gradient, Stop
+
+# Raw Transformations
+@docs Transform
+
+# LineTypes
+@docs LineType
+
+# Text and Fonts
+@docs FontAlign, Face, Font
+
+# Curve Pulls
+@docs Pull
+
+-}
+
 import Html
 import Color
 
@@ -53,23 +78,21 @@ type Shape userMsg
     | TouchMoveAt (( Float, Float ) -> userMsg) (Shape userMsg)
     | GraphPaper Float Float Color
 
-
-type FontAlign
-    = AlignLeft
-    | AlignCentred
-    | AlignRight
-
-
 {-| The `Color` type is used for filling or outlining a `Stencil`.
 -}
 type Color
     = Solid Color.Color
     | Gradient Gradient
 
+{-| A type representing radial and linear gradients.
+-}
 type Gradient =
       RadialGradient (List Stop)
     | LinearGradient Float {- rotation -} (List Stop)
 
+{-| A type representing stops in a gradient. Consists of one constructor 
+with inputs for the position, transparency and colour.
+-}
 type Stop =
     Stop Float {- stop position -} Float {- transparency -} Color.Color {- colour -}
 
@@ -115,8 +138,19 @@ type LineType
     | Broken (List ( Float, Float )) Float
 
 
+{-| A simple algebraic data type with three constructors:
+- AlignLeft
+- AlignCentred
+- AlignRight
+-}
+type FontAlign
+    = AlignLeft
+    | AlignCentred
+    | AlignRight
+
+
+
 {-| The `Face` type describes the appearance of a text `Stencil`.
-THIS IS NOT EXPOSED BY ANY TYPE AND IS NOW NOT EXPOSED BY THE LIBARY.
 -}
 type Face
     = Face
@@ -138,7 +172,6 @@ type Face
 
 
 {-| The `Font` type describes the font of a text `Stencil`.
-THIS IS NOT EXPOSED BY ANY TYPE AND IS NOW NOT EXPOSED BY THE LIBARY.
 -}
 type Font
     = Serif

--- a/src/GraphicSVG/Widget.elm
+++ b/src/GraphicSVG/Widget.elm
@@ -50,7 +50,7 @@ from this section.
 @docs viewCustom
 -}
 
-import GraphicSVG exposing(Shape(..), createSVG, ident)
+import GraphicSVG exposing(Shape, createSVG, ident)
 import Html
 import Svg
 import Svg.Attributes exposing(width,height,viewBox,clipPath,x,y,id)

--- a/src/Tests/GradientTest.elm
+++ b/src/Tests/GradientTest.elm
@@ -46,7 +46,7 @@ view model =
         |> move (-192/2,0)
     ,  circle 50
         |> filled
-            (radialGradient 50
+            (radialGradient
                 [ stop (hsla (degrees <| model.time*100) saturation lightness 0.5) 0
                 , stop (hsl (degrees <| model.time*100 + 60) saturation lightness) 10
                 , stop (hsl (degrees <| model.time*100 + 120) saturation lightness) 20

--- a/src/Tests/Park.elm
+++ b/src/Tests/Park.elm
@@ -43,7 +43,7 @@ view model =
     collage 192 128
     [ rect 192 128
               |> filled
-                    (gradient 128
+                    (gradient
                       [stop (rgb 224 255 255) 0
                       ,stop (rgb 0 191 255) 128
                       ]
@@ -53,7 +53,7 @@ view model =
               |> move (0,32)
     , rect 192 128
               |> filled
-                    (gradient 128
+                    (gradient
                         [stop lightGreen 0
                         ,stop darkGreen 128
                         ]
@@ -61,7 +61,7 @@ view model =
               |> move (0,-96)
     , circle 50
             |> filled
-                (radialGradient 50
+                (radialGradient
                     [ stop orange 0
                     , stop lightOrange 12.5
                     , stop yellow 25

--- a/src/Tests/PositionTest.elm
+++ b/src/Tests/PositionTest.elm
@@ -1,3 +1,5 @@
+module Tests.PositionTest exposing(..)
+
 import GraphicSVG exposing (..)
 import GraphicSVG.App exposing (notificationsApp, NotificationsApp, GetKeyState)
 

--- a/src/Tests/TransformationTests.elm
+++ b/src/Tests/TransformationTests.elm
@@ -1,5 +1,8 @@
+module Tests.TransformationTests exposing(..)
+
 import GraphicSVG exposing (..)
 import GraphicSVG.App exposing (appWithTick, AppWithTick, GetKeyState)
+import GraphicSVG.Secret exposing(Shape(..))
 import Url exposing (Url)
 import Browser exposing (UrlRequest)
 import Array


### PR DESCRIPTION
Split the main types in GraphicSVG out into their own module called `GraphicSVG.Secret`. Allows us to more easily inspect and modify user's shapes. For instance, we could easily resize, re-style, move, scale, etc., users' shapes. We could also use this to analyze the users' shapes.